### PR TITLE
Added UTF-8 encoding when opening files.

### DIFF
--- a/train.py
+++ b/train.py
@@ -70,7 +70,7 @@ if args.tokenizer == TOKENIZER_CHOICE_NLTK:
 # Each sentence is an array of words.
 final_sentences = []
 for file in listOfFiles:
-    text = open(file).read().lower().replace("\n", " ") # Remove lineabreaks
+    text = open(file,encoding="utf-8").read().lower().replace("\n", " ") # Remove lineabreaks
 
     # Remove all the stop words before running the actual tokenization.
     # I think it's a little bit cleaner to do it here and may perform because
@@ -100,7 +100,7 @@ model = Word2Vec(final_sentences, size=100, window=5, min_count=5, workers=4)
 model.wv.save_word2vec_format(output_text_file, binary=False)
 
 # Open up that text file and convert to JSON
-f = open(output_text_file)
+f = open(output_text_file,encoding="utf-8")
 v = {"vectors": {}}
 for line in f:
     w, n = line.split(" ", 1)
@@ -109,5 +109,5 @@ for line in f:
 # Save to a JSON file
 # Could make this an optional argument to specify output file
 with open(output_text_file[:-4] + "json", "w") as out:
-    json.dump(v, out)
-
+    json.dump(v, out, ensure_ascii=False)
+    


### PR DESCRIPTION
Hello! I was trying to train my own vector model, but got decoding errors during the linebreaks removal. I figured out that forcing the encoding (encoding="utf-8") during the file opening would fix it. Added to both input and output files. Also, added "ensure_ascii=False" to the json dump, so the "\u" characters are dumped as human readable chars.

Hope this helps, and thanks for the great work!